### PR TITLE
added capability for custom context logging

### DIFF
--- a/samples/SerilogAspnetcoreHttpcontextSample/Program.cs
+++ b/samples/SerilogAspnetcoreHttpcontextSample/Program.cs
@@ -1,7 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Serilog;
+using Serilog.Core;
 using Serilog.Enrichers.AspnetcoreHttpcontext;
 using Serilog.Events;
 using Serilog.Sinks.Elasticsearch;
@@ -22,7 +26,9 @@ namespace SerilogAspnetcoreHttpcontextSample
                 {
                     loggerConfiguration.MinimumLevel.Debug()
                         .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
-                        .Enrich.WithAspnetcoreHttpcontext(provider)
+                        .Enrich.WithAspnetcoreHttpcontext(provider, 
+                            includeUserInfo: true,
+                            customMethod: CustomEnricherLogic)
                         .WriteTo.Console(
                             outputTemplate:
                             "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {NewLine}{HttpContext} {NewLine}{Exception}")
@@ -31,5 +37,34 @@ namespace SerilogAspnetcoreHttpcontextSample
                             IndexFormat = "serilog-enrichers-aspnetcore-httpcontext-{0:yyyy.MM}"
                         });
                 });
+
+        private static void CustomEnricherLogic(IHttpContextAccessor ctx, LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            HttpContext context = ctx.HttpContext;
+            if (context == null)
+            {
+                return;
+            }
+            var userInfo = context.Items[$"serilog-enrichers-aspnetcore-userinfo"] as UserInfo;
+            if (userInfo == null)
+            {
+                var user = context.User.Identity;
+                if (user == null || !user.IsAuthenticated) return;
+                userInfo = new UserInfo
+                {
+                    Name = user.Name,
+                    Claims = context.User.Claims.ToDictionary(x => x.Type, y => y.Value)
+                };
+                context.Items[$"serilog-enrichers-aspnetcore-userinfo"] = userInfo;
+            }
+
+            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("UserInfo", userInfo, true));
+        }
+
+        public class UserInfo
+        {
+            public string Name { get; set; }
+            public Dictionary<string, string> Claims { get; set; }
+        }
     }
 }

--- a/src/Serilog.Enrichers.AspnetcoreHttpcontext/HttpContextCache.cs
+++ b/src/Serilog.Enrichers.AspnetcoreHttpcontext/HttpContextCache.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using Serilog.Formatting.Json;
 
 namespace Serilog.Enrichers.AspnetcoreHttpcontext
 {

--- a/src/Serilog.Enrichers.AspnetcoreHttpcontext/LoggerEnrichmentConfigurationExtensions.cs
+++ b/src/Serilog.Enrichers.AspnetcoreHttpcontext/LoggerEnrichmentConfigurationExtensions.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Serilog.Configuration;
+using Serilog.Core;
+using Serilog.Events;
 
 namespace Serilog.Enrichers.AspnetcoreHttpcontext
 {
@@ -16,10 +19,20 @@ namespace Serilog.Enrichers.AspnetcoreHttpcontext
         /// <param name="enrichmentConfiguration">Logger enrichment configuration.</param>
         /// <param name="serviceProvider"></param>
         /// <returns>Configuration object allowing method chaining.</returns>
-        public static LoggerConfiguration WithAspnetcoreHttpcontext(this LoggerEnrichmentConfiguration enrichmentConfiguration, IServiceProvider serviceProvider)
+        public static LoggerConfiguration WithAspnetcoreHttpcontext(this LoggerEnrichmentConfiguration enrichmentConfiguration, 
+            IServiceProvider serviceProvider, 
+            bool includeUserInfo, Action<IHttpContextAccessor, LogEvent, ILogEventPropertyFactory> customMethod = null)
         {
             if (enrichmentConfiguration == null) throw new ArgumentNullException(nameof(enrichmentConfiguration));
-            return enrichmentConfiguration.With(serviceProvider.GetService<AspnetcoreHttpcontextEnricher>());
-        }
+
+            var enricher = serviceProvider.GetService<AspnetcoreHttpcontextEnricher>();
+            if (includeUserInfo)
+                enricher.IncludeUserInfo();
+
+            if (customMethod != null)
+                enricher.SetCustomAction(customMethod);
+
+            return enrichmentConfiguration.With(enricher);
+        }        
     }
 }


### PR DESCRIPTION
Hi there!  I haven't actually EVER done code-based pull requests in the OSS community before, so this is a first for me.  Feel free to completely reject if you like.

But here's what I've done, which basically amounts to the capability to either add the user information from httpcontext as a claims identity by specifying a bool = true value when using the .WithAspnetcoreHttpcontext() extension, and also to be able to invoke a totally custom method to create whatever log properties you wanted (cookies, session, pick and choose request items, etc.).

I was trying hard to get it so that the IHttpContextAccessor was available BEFORE the webhostbuilder was created, but couldn't figure it out.  

I got the UserInfo stuff tested and working (with the custom method and the simple bool) against the demo identity server at https://demo.identityserver.io and can post the code in by own GitHub repo if you want to see it.  But it's pretty sweet (and simple).

If you don't want this type of thing in the repo or you want me to adjust what I've done in any just let me know.

Thanks - 
Erik
