### PR TITLE
New approach for consideration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # serilog-enrichers-aspnetcore-httpcontext &middot; [![NuGet](https://img.shields.io/nuget/v/Serilog.Enrichers.AspnetcoreHttpcontext.svg?style=flat-square)](https://www.nuget.org/packages/Serilog.Enrichers.AspnetcoreHttpcontext) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/trenoncourt/serilog-enrichers-aspnetcore-httpcontext/blob/master/LICENSE)
 
-> Enriches Serilog events with Aspnetcore HttpContext.
+> Enriches Serilog events with Aspnetcore HttpContext.  By default logs all information about the Http Request.  Provides access to log whatever you want from the HttpContext, 
+including Session, Cookies, Request, Connection, User - basically anything from the HttpContext object. 
 
 ## Installation
 
@@ -35,9 +36,69 @@ You'll have enriched log event like pictures listed bellow
 
 ![alt text](https://raw.githubusercontent.com/trenoncourt/serilog-enrichers-aspnetcore-httpcontext/master/samples/SerilogAspnetcoreHttpcontextSample/elastic.png)
 
-## Settings
+## The Basics
 
-Soon...
+### Move LoggerConfiguration to the UseSerilog method
+The reason for this move is becuase within ASP.NET Core the HttpContext is only available 
+after the dependency injection engine is established.  The ``LogggerConfiguration`` setup
+is the same as you would do elsewhere, just the location has moved.
+
+### Use the ``WithAspnetcoreHttpcontext`` extension method
+Using the method as shown above (with only the ``providers`` parameter passed) will use the default enrichment method.  It will format the [HttpContextCache](./src/Serilog.Enrichers.AspnetcoreHttpcontext/HttpContextCache.cs) object from this 
+project, which contains mostly information from the ``Request`` object of the ``HttpContext``.  
+
+### Provide your own method that returns what you want from HttpContext
+If you want different items from the ``HttpContext`` in your log entries, you can provide your own method to do this.  A full working example can be seen in the [samples folder](./samples).
+
+You provide a second argument to the ``WithAspnetcoreHttpcontext`` method, which is the name of a method with a signature like this:
+
+```
+SomeClassYouDefine WhateverNameYouWant(IHttpConextAccessor hca)
+```
+
+``SomeClassYouDefine`` is a simple class that you would create that contains properties for the information from the ``HttpContext`` you want in the log entry.  Then inside the method you "new up" the class into an actual object, and use the ``hca`` parameter's ``HttpContext``
+property to fill your object with whatever you want and then return the object.  
+
+Here's the example from the samples folder:
+```
+...
+            .Enrich.WithAspnetcoreHttpcontext(provider,
+                            customMethod: CustomEnricherLogic)
+...
+
+private static MyObject CustomEnricherLogic(IHttpContextAccessor ctx)
+{
+    var context = ctx.HttpContext;
+    if (context == null) return null;
+    
+    var myInfo = new MyObject
+    {
+        Path = context.Request.Path.ToString(),
+        Host = context.Request.Host.ToString(),
+        Method = context.Request.Method
+    };
+
+    var user = context.User;
+    if (user != null && user.Identity != null && user.Identity.IsAuthenticated)
+    {
+        myInfo.UserClaims = user.Claims.Select(a => new KeyValuePair<string, string>(a.Type, a.Value)).ToList();
+    }
+    return myInfo;
+}
+
+public class MyObject
+{
+    public string Path { get; set; }
+    public string Host { get; set; }
+    public string Method { get; set; }
+
+    public List<KeyValuePair<string, string>> UserClaims { get; set; }
+}
+
+```
+
+### Format (or don't) your log entries
+Either the standard ``HttpContextCache`` class or your own custom class will be added to the log entry as the ``HttpContext`` property.  You can use this in your custom formatting logic or just leave it to the built-in formatters to handle.
 
 ## Contributing
 

--- a/samples/SerilogAspnetcoreHttpcontextSample/Program.cs
+++ b/samples/SerilogAspnetcoreHttpcontextSample/Program.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -46,6 +48,12 @@ namespace SerilogAspnetcoreHttpcontextSample
                 Host = context.Request.Host.ToString(),
                 Method = context.Request.Method
             };
+
+            var user = context.User;
+            if (user != null && user.Identity != null && user.Identity.IsAuthenticated)
+            {
+                myInfo.UserClaims = user.Claims.Select(a => new KeyValuePair<string, string>(a.Type, a.Value)).ToList();
+            }
             return myInfo;
         }
 
@@ -54,6 +62,8 @@ namespace SerilogAspnetcoreHttpcontextSample
             public string Path { get; set; }
             public string Host { get; set; }
             public string Method { get; set; }
+
+            public List<KeyValuePair<string, string>> UserClaims { get; set; }
         }
     }
 }

--- a/samples/SerilogAspnetcoreHttpcontextSample/Program.cs
+++ b/samples/SerilogAspnetcoreHttpcontextSample/Program.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -26,45 +24,36 @@ namespace SerilogAspnetcoreHttpcontextSample
                 {
                     loggerConfiguration.MinimumLevel.Debug()
                         .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
-                        .Enrich.WithAspnetcoreHttpcontext(provider, 
-                            includeUserInfo: true,
+                        .Enrich.WithAspnetcoreHttpcontext(provider,
                             customMethod: CustomEnricherLogic)
                         .WriteTo.Console(
                             outputTemplate:
-                            "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {NewLine}{HttpContext} {NewLine}{Exception}")
-                        .WriteTo.Elasticsearch(new ElasticsearchSinkOptions(new Uri("http://localhost:9200"))
-                        {
-                            IndexFormat = "serilog-enrichers-aspnetcore-httpcontext-{0:yyyy.MM}"
-                        });
+                            "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {NewLine}{HttpContext} {NewLine}{Exception}");
+                    //.WriteTo.Elasticsearch(new ElasticsearchSinkOptions(new Uri("http://localhost:9200"))
+                    //{
+                    //    IndexFormat = "serilog-enrichers-aspnetcore-httpcontext-{0:yyyy.MM}"
+                    //});
                 });
 
-        private static void CustomEnricherLogic(IHttpContextAccessor ctx, LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        private static MyObject CustomEnricherLogic(IHttpContextAccessor ctx)
         {
-            HttpContext context = ctx.HttpContext;
-            if (context == null)
+            var context = ctx.HttpContext;
+            if (context == null) return null;
+            
+            var myInfo = new MyObject
             {
-                return;
-            }
-            var userInfo = context.Items[$"serilog-enrichers-aspnetcore-userinfo"] as UserInfo;
-            if (userInfo == null)
-            {
-                var user = context.User.Identity;
-                if (user == null || !user.IsAuthenticated) return;
-                userInfo = new UserInfo
-                {
-                    Name = user.Name,
-                    Claims = context.User.Claims.ToDictionary(x => x.Type, y => y.Value)
-                };
-                context.Items[$"serilog-enrichers-aspnetcore-userinfo"] = userInfo;
-            }
-
-            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("UserInfo", userInfo, true));
+                Path = context.Request.Path.ToString(),
+                Host = context.Request.Host.ToString(),
+                Method = context.Request.Method
+            };
+            return myInfo;
         }
 
-        public class UserInfo
+        public class MyObject
         {
-            public string Name { get; set; }
-            public Dictionary<string, string> Claims { get; set; }
+            public string Path { get; set; }
+            public string Host { get; set; }
+            public string Method { get; set; }
         }
     }
 }

--- a/src/Serilog.Enrichers.AspnetcoreHttpcontext/AspnetcoreHttpcontextEnricher.cs
+++ b/src/Serilog.Enrichers.AspnetcoreHttpcontext/AspnetcoreHttpcontextEnricher.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
-using System.Security.Claims;
 using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
@@ -13,80 +12,67 @@ namespace Serilog.Enrichers.AspnetcoreHttpcontext
     public class AspnetcoreHttpcontextEnricher : ILogEventEnricher
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
-        private bool _includeUserInfo = false;
-        private Action<IHttpContextAccessor, LogEvent, ILogEventPropertyFactory> _customAction = null;
+        private Func<IHttpContextAccessor, object> _customAction = null;
 
         public AspnetcoreHttpcontextEnricher(IHttpContextAccessor httpContextAccessor)
         {
-            _httpContextAccessor = httpContextAccessor;            
-        }
+            _httpContextAccessor = httpContextAccessor;
+            _customAction = StandardEnricher;  // by default
 
-        public void IncludeUserInfo()
-        {
-            _includeUserInfo = true;
-        }
-
-        public void SetCustomAction(Action<IHttpContextAccessor, LogEvent, ILogEventPropertyFactory> customAction)
+        }        
+        public void SetCustomAction(Func<IHttpContextAccessor, object> customAction)
         {
             _customAction = customAction;
-        }
-        
+        }        
+
         public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
         {
             HttpContext ctx = _httpContextAccessor.HttpContext;
-            if (ctx == null)
-            {
-                return;
-            }
-            var httpContextCache = ctx.Items[$"serilog-enrichers-aspnetcore-httpcontext"] as HttpContextCache;
+            if (ctx == null) return;
+
+            var httpContextCache = ctx.Items[$"serilog-enrichers-aspnetcore-httpcontext"];
+
             if (httpContextCache == null)
             {
-                httpContextCache = new HttpContextCache
-                {
-                    IpAddress = ctx.Connection.RemoteIpAddress.ToString(),
-                    Host = ctx.Request.Host.ToString(),
-                    Path = ctx.Request.Path.ToString(),
-                    IsHttps = ctx.Request.IsHttps,
-                    Scheme = ctx.Request.Scheme,
-                    Method = ctx.Request.Method,
-                    ContentType = ctx.Request.ContentType,
-                    Protocol = ctx.Request.Protocol,
-                    QueryString = ctx.Request.QueryString.ToString(),
-                    Query = ctx.Request.Query.ToDictionary(x => x.Key, y => y.Value.ToString()),
-                    Headers = ctx.Request.Headers.ToDictionary(x => x.Key, y => y.Value.ToString()),
-                    Cookies = ctx.Request.Cookies.ToDictionary(x => x.Key, y => y.Value.ToString())
-                };
-
-                if (ctx.Request.ContentLength.HasValue && ctx.Request.ContentLength > 0)
-                {
-                    ctx.Request.EnableRewind();
-                
-                    using (StreamReader reader = new StreamReader(ctx.Request.Body, Encoding.UTF8, true, 1024, true))
-                    {
-                        httpContextCache.Body = reader.ReadToEnd();
-                    }
-                    
-                    ctx.Request.Body.Position = 0;
-                }
+                httpContextCache = _customAction.Invoke(_httpContextAccessor);
                 ctx.Items[$"serilog-enrichers-aspnetcore-httpcontext"] = httpContextCache;
             }
-            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("HttpContext", httpContextCache, true));
+            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("HttpContext", httpContextCache, true));             
+        }
 
-            if (_includeUserInfo)
+        public static object StandardEnricher(IHttpContextAccessor hca)
+        {
+            var ctx = hca.HttpContext;
+            if (ctx == null) return null;
+
+            var httpContextCache = new HttpContextCache
             {
-                var x = ctx.User as ClaimsPrincipal;
-                if (x != null && x.Identity != null && x.Identity.IsAuthenticated)
+                IpAddress = ctx.Connection.RemoteIpAddress.ToString(),
+                Host = ctx.Request.Host.ToString(),
+                Path = ctx.Request.Path.ToString(),
+                IsHttps = ctx.Request.IsHttps,
+                Scheme = ctx.Request.Scheme,
+                Method = ctx.Request.Method,
+                ContentType = ctx.Request.ContentType,
+                Protocol = ctx.Request.Protocol,
+                QueryString = ctx.Request.QueryString.ToString(),
+                Query = ctx.Request.Query.ToDictionary(x => x.Key, y => y.Value.ToString()),
+                Headers = ctx.Request.Headers.ToDictionary(x => x.Key, y => y.Value.ToString()),
+                Cookies = ctx.Request.Cookies.ToDictionary(x => x.Key, y => y.Value.ToString())
+            };
+
+            if (ctx.Request.ContentLength.HasValue && ctx.Request.ContentLength > 0)
+            {
+                ctx.Request.EnableRewind();
+
+                using (StreamReader reader = new StreamReader(ctx.Request.Body, Encoding.UTF8, true, 1024, true))
                 {
-                    var claims = x.Claims.ToDictionary(c => c.Type, v => v.Value);
-                    logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("UserInfo", claims, false));
+                    httpContextCache.Body = reader.ReadToEnd();
                 }
-            }
 
-            if (_customAction != null)
-            {
-                _customAction.Invoke(_httpContextAccessor, logEvent, propertyFactory);
+                ctx.Request.Body.Position = 0;
             }
-                
+            return httpContextCache;
         }
     }
 }

--- a/src/Serilog.Enrichers.AspnetcoreHttpcontext/LoggerEnrichmentConfigurationExtensions.cs
+++ b/src/Serilog.Enrichers.AspnetcoreHttpcontext/LoggerEnrichmentConfigurationExtensions.cs
@@ -20,14 +20,11 @@ namespace Serilog.Enrichers.AspnetcoreHttpcontext
         /// <param name="serviceProvider"></param>
         /// <returns>Configuration object allowing method chaining.</returns>
         public static LoggerConfiguration WithAspnetcoreHttpcontext(this LoggerEnrichmentConfiguration enrichmentConfiguration, 
-            IServiceProvider serviceProvider, 
-            bool includeUserInfo, Action<IHttpContextAccessor, LogEvent, ILogEventPropertyFactory> customMethod = null)
+            IServiceProvider serviceProvider, Func<IHttpContextAccessor, object> customMethod = null)
         {
             if (enrichmentConfiguration == null) throw new ArgumentNullException(nameof(enrichmentConfiguration));
 
-            var enricher = serviceProvider.GetService<AspnetcoreHttpcontextEnricher>();
-            if (includeUserInfo)
-                enricher.IncludeUserInfo();
+            var enricher = serviceProvider.GetService<AspnetcoreHttpcontextEnricher>();            
 
             if (customMethod != null)
                 enricher.SetCustomAction(customMethod);


### PR DESCRIPTION
I think this would in general leave things alone for anyone already using it, but enable folks to use it out of the box in a clean way when they have custom needs.  The sample app shows how you'd use it to do custom logging -- without including the stuff from the original log entries.

And if the caller doesn't provide a custom function then it would behave as it had before - logging a full HttpContextCache object.

I've been thinking about this and it would seem like flags to include this, exclude that, but only when X -- it would be hard to anticipate all of the real needs from different applications.  And so use the out-of-the-box approach when they have simple needs, and just a simple custom function when they want to specify their own stuff.  

Thoughts?
